### PR TITLE
Enable Muon to send the Content-Type of the data.

### DIFF
--- a/create-db.sh
+++ b/create-db.sh
@@ -3,6 +3,6 @@
 mkdir db 2> /dev/null
 rm db/database.db 2> /dev/null
 sqlite3 db/database.db << EOF
-create table data(id integer primary key autoincrement, text longtext, type char(5), policy char(20), expires_at timestamp, max_visits int, visits int);
+create table data(id integer primary key autoincrement, text longtext, type char(5), policy char(20), expires_at timestamp, max_visits int, visits int, mime varchar);
 EOF
 

--- a/src/muon/handler.clj
+++ b/src/muon/handler.clj
@@ -17,6 +17,9 @@
 ; Change the password!!
 (def PASSWORD "password")
 
+; Default Content-Type
+(def MIME "application/octet-stream")
+
 (defn build-url
   [& args]
   (reduce str DOMAIN_ROOT args))
@@ -56,18 +59,18 @@
    :body "Internal server error, this should NOT happen."})
 
 (defn save-to-db
-  [text type opts]
+  [text type mime opts]
   (let [duration (try (Integer/parseInt (:duration opts)) (catch Exception e nil))
         clicks (try (Integer/parseInt (:clicks opts)) (catch Exception e nil))]
     (cond
      (and (nil? duration) (nil? clicks)) wrong-options
      (not (nil? clicks))
-       (let [res (db/insert! (db-connection) :data {:text text :type (name type) :policy "clicks" :expires_at 0 :max_visits clicks :visits 0})]
+       (let [res (db/insert! (db-connection) :data {:text text :type (name type) :mime mime :policy "clicks" :expires_at 0 :max_visits clicks :visits 0})]
          (build-url
           "resource/"
           (str (last (first (first res))) "\n")))
      (not (nil? duration))
-       (let [res (db/insert! (db-connection) :data {:text text :type (name type) :policy "timed" :expires_at (+ (System/currentTimeMillis) (* duration 1000)) :max_visits 0 :visits 0})]
+       (let [res (db/insert! (db-connection) :data {:text text :type (name type) :mime mime :policy "timed" :expires_at (+ (System/currentTimeMillis) (* duration 1000)) :max_visits 0 :visits 0})]
          (build-url
           "resource/"
           (str (last (first (first res))) "\n")))
@@ -77,21 +80,21 @@
   [data]
   (let [filename (str "resources/" (System/currentTimeMillis))]
     (io/copy (:tempfile (:file data)) (io/as-file filename))
-    (save-to-db filename :file data)))
+    (save-to-db filename :file (or (:content-type (:file data)) MIME) data)))
 
 (defn handle-text-upload
   [data]
-  (save-to-db (:text data) :text data))
+  (save-to-db (:text data) :text "text/plain" data))
 
 (defn build-response
-  [text type]
+  [text type mime]
   (cond
-   (= "file" type) (res/file-response text)
-   (= "text" type) {:status 200 :headers {} :body text}
+   (= "file" type) (res/content-type (res/file-response text) mime)
+   (= "text" type) {:status 200 :headers {"Content-Type" mime} :body text}
    :else internal-error))
 
 (defn check-expired
-  [{:keys [id text type policy expires_at max_visits visits]}]
+  [{:keys [id text type policy expires_at max_visits visits mime]}]
   (if (or (and (= "timed" policy)
                (> (System/currentTimeMillis) expires_at))
           (and (= "clicks" policy)
@@ -101,7 +104,7 @@
      :body "This file has expired.\n"}
     (do
       (db/execute! (db-connection) [(str "update data set visits = (visits + 1) where id =" id)])
-      (build-response text type))))
+      (build-response text type (or mime MIME)))))
 
 (defn return-data
   [id]


### PR DESCRIPTION
Add a mime column to the data table
 ALTER TABLE data ADD COLUMN mime VARCHAR; -- Update existing database
Use content-type "text/plain" for text uploads.
Detect the uploaded content-type or default to "application/octet-stream"
